### PR TITLE
feat: add schema type support for Collection and double

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -72,11 +72,11 @@ export function parseAst2StandardDataType(
   const { name, templateArgs } = ast;
   let typeName = name;
 
-  if (name === 'List') {
+  if (['List', 'Collection'].includes(name)) {
     typeName = 'Array';
   }
 
-  if (name === 'long') {
+  if (['long', 'double'].includes(name)) {
     typeName = 'number';
   }
 


### PR DESCRIPTION
在使用过程发现某些java基础类型还不支持，这里添加了一下`double`和`Collection`。

```json
        "Result«Collection«string»»": {
            "type": "object",
            "properties": {
                ...
            },
            "title": "Result«Collection«string»»"
        }
```

```json
        "Result«double»": {
            "type": "object",
            "properties": {
                ...
            },
            "title": "Result«double»"
        }
```
