### PR TITLE
【长期未回应】接口参数增加header类型，getParamsCode方法过滤header

### DIFF
--- a/src/standard.ts
+++ b/src/standard.ts
@@ -175,9 +175,9 @@ export class StandardDataType extends Contextable {
     this.templateIndex = index;
   }
 
-  getDefNameWithTemplate() {}
+  getDefNameWithTemplate() { }
 
-  generateCodeWithTemplate() {}
+  generateCodeWithTemplate() { }
 
   getDefName(originName) {
     let name = this.typeName;
@@ -265,7 +265,7 @@ export class Property extends Contextable {
   name: string;
   required: boolean;
 
-  in: 'query' | 'body' | 'path';
+  in: 'query' | 'body' | 'path' | 'header';
 
   setContext(context) {
     super.setContext(context);
@@ -334,9 +334,9 @@ export class Interface extends Contextable {
     return `
       class ${className} {
         ${this.parameters
-          .filter(param => param.in !== 'body')
-          .map(param => param.toPropertyCode(true))
-          .join('')}
+        .filter(param => param.in !== 'body' && param.in !== 'header')
+        .map(param => param.toPropertyCode(true))
+        .join('')}
       }
     `;
   }


### PR DESCRIPTION
swigger 解析出来的参数中包含header，然而header往往是统一处理的，不应该放在参数中。