### PR TITLE
fix: fix error when parameters in path item object

### DIFF
--- a/src/scripts/swagger.ts
+++ b/src/scripts/swagger.ts
@@ -9,6 +9,7 @@ import {
   hasChinese,
   transformModsName
 } from '../utils';
+import { Omit } from '../utilTypes';
 import { compileTemplate, parseAst2StandardDataType } from '../compiler';
 
 import { OriginBaseReader } from './base';
@@ -258,15 +259,22 @@ class SwaggerInterface {
   }
 }
 
+interface SwaggerReferenceObject {
+  $ref: string;
+}
+
+// TODO: $ref, options, head
+interface SwaggerPathItemObject {
+  get?: SwaggerInterface;
+  post?: SwaggerInterface;
+  put?: SwaggerInterface;
+  patch?: SwaggerInterface;
+  delete?: SwaggerInterface;
+  parameters?: SwaggerParameter[] | SwaggerReferenceObject[];
+}
+
 export class SwaggerDataSource {
-  paths: {
-    [key in string]: {
-      put: SwaggerInterface;
-      delete: SwaggerInterface;
-      post: SwaggerInterface;
-      get: SwaggerInterface;
-    }
-  };
+  paths: { [key in string]: SwaggerPathItemObject };
   tags: { name: string; description: string }[];
   definitions: {
     [key in string]: {
@@ -280,7 +288,21 @@ export class SwaggerDataSource {
 export function parseSwaggerMods(swagger: SwaggerDataSource, defNames: string[], usingOperationId: boolean) {
   const allSwaggerInterfaces = [] as SwaggerInterface[];
   _.forEach(swagger.paths, (methodInters, path) => {
-    _.forEach(methodInters, (inter, method) => {
+    const pathItemObject = _.cloneDeep(methodInters);
+
+    if (Array.isArray(pathItemObject.parameters)) {
+      ['get', 'post', 'patch', 'delete', 'put'].forEach(method => {
+        if (pathItemObject[method]) {
+          pathItemObject[method].parameters = (pathItemObject[method].parameters || []).concat(
+            pathItemObject.parameters
+          );
+        }
+      });
+
+      delete pathItemObject.parameters;
+    }
+
+    _.forEach(pathItemObject as Omit<SwaggerPathItemObject, 'parameters'>, (inter, method) => {
       inter.path = path;
       inter.method = method;
       allSwaggerInterfaces.push(inter);

--- a/src/utilTypes.ts
+++ b/src/utilTypes.ts
@@ -1,0 +1,1 @@
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;


### PR DESCRIPTION
https://swagger.io/specification/v2/#pathsObject
When pathsObject has parameters property,  allSwaggerInterfaces will be unexpected value,
inter.tags.includes will throw error "cannot read property 'includes' of undefined"

parseSwaggerMods中处理allSwaggerInterfaces没考虑path下面有公共参数parameters的情况


下图这样的接口就会报错
<img width="503" alt="path with parameters" src="https://user-images.githubusercontent.com/5419886/58899089-a94aae80-872e-11e9-8bf9-ba67eada8750.png">
