### PR TITLE
【长期未回应】dataSource默认处理优化

### DIFF
--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -88,7 +88,7 @@ export function parseAst2StandardDataType(
     typeName = 'ObjectMap';
   }
 
-  const isDefsType = defNames.includes(name);
+  const isDefsType = defNames.includes(name) && typeName === name;
   const typeArgs = templateArgs.map(arg => {
     return parseAst2StandardDataType(arg, defNames, classTemplateArgs);
   });

--- a/src/scripts/swagger.ts
+++ b/src/scripts/swagger.ts
@@ -207,6 +207,11 @@ class SwaggerInterface {
       name = getIdentifierFromOperatorId(inter.operationId);
     }
 
+    name = transformCamelCase(name);
+    if (name === 'index') {
+      name = 'indexApi';
+    }
+
     const responseSchema = _.get(inter, 'responses.200.schema', {}) as Schema;
     const response = Schema.parseSwaggerSchema2StandardDataType(responseSchema, defNames);
 


### PR DESCRIPTION
1. 当类型为被转义时，统一设置isDefsType为false。举例：Map<string, array>直接定义为ObjectMap，而不是defs.ObjectMap
2. 处理接口名称的驼峰转换，特别是对于swagger定义中接口名包含空格的转换很重要。另外特殊处理接口名为index时的转换，因为index在生成mod代码时是保留字