### PR TITLE
refactor: remove unused code

### DIFF
--- a/src/LocalDictManager.ts
+++ b/src/LocalDictManager.ts
@@ -1,10 +1,6 @@
-import * as _ from 'lodash';
-const { youdao, baidu, google } = require('translation.js');
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import * as os from 'os';
-import * as assert from 'assert';
-import * as debugLog from './debugLog';
 
 class LocalDictManager {
   static singleInstance = null as LocalDictManager;

--- a/src/cmd.ts
+++ b/src/cmd.ts
@@ -47,7 +47,7 @@ function assert(expression: boolean, message: string) {
               });
             });
 
-            data.mods.forEach((mod, modIndex) => {
+            data.mods.forEach(mod => {
               assert(!!mod.name, `描述为 ${mod.description} 的模块没有 "name" 属性`);
 
               mod.interfaces.forEach(inter => {

--- a/src/diff.ts
+++ b/src/diff.ts
@@ -1,4 +1,4 @@
-import { Mod, Interface, BaseClass, Property } from './standard';
+import { Mod, Interface, BaseClass } from './standard';
 import * as _ from 'lodash';
 
 export interface Model extends Mod {
@@ -24,7 +24,7 @@ function analyWithName(preEntities: Entity[], nextEntities: Entity[]) {
 }
 
 function deepDifInterface(preInter: Interface, nextInter: Interface, preLabel: string): string[] {
-  const { parameters, response, description, method } = preInter;
+  const { parameters, description, method } = preInter;
   const details = [] as string[];
 
   if (description !== nextInter.description) {

--- a/src/generators/generate.ts
+++ b/src/generators/generate.ts
@@ -9,12 +9,10 @@
 
 import * as _ from 'lodash';
 import { StandardDataSource, Interface, Mod, BaseClass } from '../standard';
-import { Config } from '../utils';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { format } from '../utils';
 import { info } from '../debugLog';
-import { existsSync } from 'fs-extra';
 
 export class FileStructures {
   constructor(private generators: CodeGenerator[], private usingMultipleOrigins: boolean) {}
@@ -162,7 +160,7 @@ export class CodeGenerator {
   /** 获取某个基类的类型定义代码 */
   getBaseClassInDeclaration(base: BaseClass) {
     if (base.templateArgs && base.templateArgs.length) {
-      return `class ${base.name}<${base.templateArgs.map((ignored, index) => `T${index} = any`).join(', ')}> {
+      return `class ${base.name}<${base.templateArgs.map((_, index) => `T${index} = any`).join(', ')}> {
         ${base.properties.map(prop => prop.toPropertyCode(true)).join('\n')}
       }
       `;
@@ -468,7 +466,6 @@ export class FilesManager {
       }
 
       await fs.mkdir(`${dir}/${name}`);
-      // this.report(`文件夹${name}创建成功!`);
       await this.generateFiles(value, `${dir}/${name}`);
     });
 

--- a/src/manage.ts
+++ b/src/manage.ts
@@ -5,7 +5,6 @@ import * as path from 'path';
 import { diff, Model } from './diff';
 import { FilesManager } from './generators/generate';
 import { info as debugInfo } from './debugLog';
-import * as _ from 'lodash';
 import { FileStructures } from './generators/generate';
 import { readRemoteDataSource } from './scripts';
 

--- a/src/scripts/base.ts
+++ b/src/scripts/base.ts
@@ -43,7 +43,7 @@ export class OriginBaseReader {
   }
 
   /** 数据转换，可覆盖 */
-  transform2Standard(data, usingOperationId: boolean, originName: string) {
+  transform2Standard(data, _usingOperationId: boolean, _originName: string) {
     return data;
   }
 

--- a/src/scripts/index.ts
+++ b/src/scripts/index.ts
@@ -1,5 +1,3 @@
-import * as _ from 'lodash';
-import { OriginBaseReader } from './base';
 import { SwaggerV2Reader } from './swagger';
 import { DataSourceConfig } from '../utils';
 

--- a/src/scripts/swagger.ts
+++ b/src/scripts/swagger.ts
@@ -387,7 +387,7 @@ export function transformSwaggerData2Standard(swagger: SwaggerDataSource, usingO
     const requiredProps = clazz.def.required || [];
 
     const props = _.map(properties, (prop, propName) => {
-      const { $ref, description, name, type, items, additionalProperties } = prop;
+      const { $ref, description, type, items, additionalProperties } = prop;
       const required = requiredProps.includes(propName);
 
       const dataType = Schema.parseSwaggerSchema2StandardDataType(

--- a/src/standard.ts
+++ b/src/standard.ts
@@ -1,7 +1,6 @@
 import * as _ from 'lodash';
 import { getDuplicateById } from './utils';
 import { compileTemplate, parseAst2StandardDataType } from './compiler';
-import { type } from 'os';
 
 // primitive type
 export enum PrimitiveType {
@@ -282,7 +281,6 @@ export class Property extends Contextable {
   }
 
   toPropertyCode(hasRequired = false, optional = false) {
-    const dataType = this.dataType;
     let optionalSignal = hasRequired && optional ? '?' : '';
 
     if (hasRequired && !this.required) {
@@ -300,7 +298,6 @@ export class Property extends Contextable {
   }
 
   toPropertyCodeWithInitValue(baseName = '') {
-    const dataType = this.dataType;
     let typeWithValue = `= ${this.dataType.getInitialValue(false)}`;
 
     if (!this.dataType.getInitialValue(false)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -142,14 +142,7 @@ export class DataSourceConfig {
   }
 }
 
-function wait(timeout = 100) {
-  return new Promise(resolve => {
-    setTimeout(resolve, timeout);
-  });
-}
-
 export function format(fileContent: string, prettierOpts = {}) {
-  // return fileContent;
   try {
     return prettier.format(fileContent, {
       parser: 'typescript',
@@ -161,18 +154,6 @@ export function format(fileContent: string, prettierOpts = {}) {
     error(`代码格式化报错！${e.toString()}\n代码为：${fileContent}`);
     return fileContent;
   }
-  // try {
-  //   await wait(Math.random() * 100);
-  //   return prettier.format(fileContent, {
-  //     parser: "typescript",
-  //     trailingComma: "all",
-  //     singleQuote: true,
-  //     ...prettierOpts
-  //   });
-  // } catch (e) {
-  //   console.log("prettier format 错误", fileContent, e);
-  //   return format(fileContent, prettierOpts);
-  // }
 }
 
 export function getDuplicateById<T>(arr: T[], idKey = 'name'): null | T {

--- a/test/test.ts
+++ b/test/test.ts
@@ -29,7 +29,7 @@ describe('pont功能测试', () => {
     // 清除路径
     clearDir('services');
 
-    server.listen({ port: 9090 }, async err => {
+    server.listen({ port: 9090 }, async () => {
       console.log('http server start successfull');
       await createManager('config-multiple-origins.json');
       // 读取 api.d.ts 并转换为单行

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,8 @@
     "moduleResolution": "node",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "baseUrl": ".",
     "paths": {
       "src": ["./src"]


### PR DESCRIPTION
Too much unused code can make reading code difficult, so open the noUnusedLocals, noUnusedParameters  in tsconfig to remove useless code

过多的无用代码会让阅读代码变得困难，所以打开tsconfig中 noUnusedLocals, noUnusedParameters两个选项，移除无用的代码
