### PR TITLE
添加js类型文件输出，支持单模块合并

### DIFF
--- a/src/generators/generate.ts
+++ b/src/generators/generate.ts
@@ -517,12 +517,12 @@ export class FilesManager {
         moduleResult = require(jsName);
       }
       // 删除该文件
-      fs.removeSync(fielName);
+      // fs.removeSync(fielName);
     } catch (e) {
       // 删除失败，则再删除
-      if (fs.existsSync(fielName)) {
-        fs.removeSync(fielName);
-      }
+      // if (fs.existsSync(fielName)) {
+      //   fs.removeSync(fielName);
+      // }
       // 没有引用，报错
       if (!moduleResult && !isTsDeclareFile) {
         throw new Error(e);

--- a/src/manage.ts
+++ b/src/manage.ts
@@ -255,7 +255,7 @@ export class Manager {
 
   async regenerateFiles() {
     this.setFilesManager();
-    await this.fileManager.regenerate();
+    await this.fileManager.regenerate(null, this.currConfig.usingTsCompiler);
   }
 
   setFilesManager() {

--- a/src/manage.ts
+++ b/src/manage.ts
@@ -255,7 +255,7 @@ export class Manager {
 
   async regenerateFiles() {
     this.setFilesManager();
-    await this.fileManager.regenerate(null, this.currConfig.usingTsCompiler, this.currConfig.mergeDirc);
+    await this.fileManager.regenerate(null, this.currConfig.useJs, this.currConfig.mergeDirc);
   }
 
   setFilesManager() {

--- a/src/manage.ts
+++ b/src/manage.ts
@@ -255,7 +255,7 @@ export class Manager {
 
   async regenerateFiles() {
     this.setFilesManager();
-    await this.fileManager.regenerate(null, this.currConfig.usingTsCompiler);
+    await this.fileManager.regenerate(null, this.currConfig.usingTsCompiler, this.currConfig.mergeDirc);
   }
 
   setFilesManager() {

--- a/src/scripts/base.ts
+++ b/src/scripts/base.ts
@@ -79,7 +79,6 @@ export class OriginBaseReader {
   async fetchRemoteData(): Promise<StandardDataSource> {
     try {
       const data = await this.fetchData();
-
       // 将数据源转换为标准数据源格式
       let remoteDataSource = this.transform2Standard(data, this.config.usingOperationId, this.config.name);
       this.report('远程数据解析完毕!');

--- a/src/scripts/swagger.ts
+++ b/src/scripts/swagger.ts
@@ -294,7 +294,7 @@ class SwaggerInterface {
 
     const parameters = (inter.parameters || []).map(param => {
       let paramSchema: Schema;
-      const { description, items, name, type, schema = {} as Schema, required } = param;
+      const { description, items, name = '', type, schema = {} as Schema, required } = param;
       // 如果请求参数在body中的话，处理方式与response保持一致，因为他们本身的结构是一样的
       if (param.in === 'body') {
         paramSchema = param.schema;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -52,6 +52,7 @@ export class Config {
   }>;
   usingMultipleOrigins = false;
   usingTsCompiler = false;
+  mergeDirc = false;
   templatePath = 'serviceTemplate';
   prettierConfig: ResolveConfigOptions;
   transformPath?: string;
@@ -123,6 +124,7 @@ export class Config {
       outDir: path.join(configDir, this.outDir),
       usingMultipleOrigins: this.usingMultipleOrigins,
       usingTsCompiler: this.usingTsCompiler,
+      mergeDirc: this.mergeDirc,
       templatePath: path.join(configDir, this.templatePath),
       transformPath: this.transformPath ? path.join(configDir, this.transformPath) : undefined,
       fetchMethodPath: this.fetchMethodPath ? path.join(configDir, this.fetchMethodPath) : undefined,
@@ -156,6 +158,7 @@ export class DataSourceConfig {
   usingOperationId = false;
   usingMultipleOrigins = false;
   usingTsCompiler? = false;
+  mergeDirc? = false;
   taggedByName = true;
   templatePath = 'serviceTemplate';
   outDir = 'src/service';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,7 +51,7 @@ export class Config {
     fetchMethodPath?: string;
   }>;
   usingMultipleOrigins = false;
-  usingTsCompiler = false;
+  useJs = false;
   mergeDirc = false;
   templatePath = 'serviceTemplate';
   prettierConfig: ResolveConfigOptions;
@@ -123,7 +123,7 @@ export class Config {
       taggedByName: this.taggedByName,
       outDir: path.join(configDir, this.outDir),
       usingMultipleOrigins: this.usingMultipleOrigins,
-      usingTsCompiler: this.usingTsCompiler,
+      useJs: this.useJs,
       mergeDirc: this.mergeDirc,
       templatePath: path.join(configDir, this.templatePath),
       transformPath: this.transformPath ? path.join(configDir, this.transformPath) : undefined,
@@ -157,7 +157,7 @@ export class DataSourceConfig {
   name?: string;
   usingOperationId = false;
   usingMultipleOrigins = false;
-  usingTsCompiler? = false;
+  useJs? = false;
   mergeDirc? = false;
   taggedByName = true;
   templatePath = 'serviceTemplate';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,6 +51,7 @@ export class Config {
     fetchMethodPath?: string;
   }>;
   usingMultipleOrigins = false;
+  usingTsCompiler = false;
   templatePath = 'serviceTemplate';
   prettierConfig: ResolveConfigOptions;
   transformPath?: string;
@@ -121,6 +122,7 @@ export class Config {
       taggedByName: this.taggedByName,
       outDir: path.join(configDir, this.outDir),
       usingMultipleOrigins: this.usingMultipleOrigins,
+      usingTsCompiler: this.usingTsCompiler,
       templatePath: path.join(configDir, this.templatePath),
       transformPath: this.transformPath ? path.join(configDir, this.transformPath) : undefined,
       fetchMethodPath: this.fetchMethodPath ? path.join(configDir, this.fetchMethodPath) : undefined,
@@ -153,6 +155,7 @@ export class DataSourceConfig {
   name?: string;
   usingOperationId = false;
   usingMultipleOrigins = false;
+  usingTsCompiler? = false;
   taggedByName = true;
   templatePath = 'serviceTemplate';
   outDir = 'src/service';


### PR DESCRIPTION
## What kind of change does this PR introduce(这个 PR 引入了什么样的变化)?

- [x] Bugfix(transformSwaggerInterface2Standard,读取param可能存在name为空的问题，会导致文件生成失败，使用起来不太友好)
- [x] Feature(增加useJs参数，支持js文件类型输出)
- [x] Feature(添加mergeDirc参数，支持合并模块文件)
- [x] pont-config配置
```json
{
  "originType": "SwaggerV2",
  "originUrl": "https://petstore.swagger.io/v2/swagger.json",
  "mergeDirc": true,
  "useJs": true
}
```
- [x] swaggerTemplate配置
```javascript

import * as Pont from 'pont-engine';
import { CodeGenerator, Interface, Mod } from "pont-engine";

export class FileStructures extends Pont.FileStructures {
}

export default class MyGenerator extends CodeGenerator {
    /** 获取接口实现内容的代码 */
    getInterfaceContent(inter: Interface) {
        const paramNotes = (inter.parameters || [])
            .filter(param => param.in !== 'body') || [];
        const urlPrefix = this.dataSource.name ? `/${this.dataSource.name}` : '';
        const required = (required) => required ? '必填项' : '';
        return `
        /**
         * @desc ${inter.description}
        * ${paramNotes.map((note, i) => `${i > 0 ? '* ' : ''}@param ${note.name} ${note.description || ''} ${required(note.required)} ${note.dataType.typeName}`).join('\n')}
         */
        export async function ${inter.name}(params) {
            return request('${urlPrefix}${inter.path}', { method: '${inter.method}', data: params });
        }`;
    }
    /** 获取单个模块的 index 入口文件, 配合mergeDirc配置，可合并模块所有request文件到模块.ts */
    getModIndex(mod: Mod) {
        return `
      /**
       * @description ${mod.description}
       */
      import request from '../utils/request';
      ${mod.interfaces
                .map(inter => {
                    return this.getInterfaceContent(inter);
                })
                .join('\n')}
    `;
    }
    /** 获取接口类和基类的总的 index 入口文件代码 */
    getIndex() {
        let conclusion = `
      import * as defs from './baseClass';
      import './mods/';

      (window as any).defs = defs;
    `;

        // dataSource name means multiple dataSource
        if (this.dataSource.name) {
            conclusion = `
        import { ${this.dataSource.name} as defs } from './baseClass';
        export { ${this.dataSource.name} } from './mods/';
        export { defs };
      `;
        }

        return conclusion;
    }
}  

```
- [x] 实现效果
![image](https://user-images.githubusercontent.com/19896792/64756357-3177f580-d561-11e9-974d-bb1286ccc03e.png)
![image](https://user-images.githubusercontent.com/19896792/64756367-418fd500-d561-11e9-8810-552641626625.png)

## Does this PR introduce a breaking change(这次 PR 引入了一个重大变化吗)?

- [x] No(否)

If yes, please describe the impact and migration path for existing applications(如果是，请描述现有应用程序的影响和迁移路径):

## The PR fulfills these requirements(PR 符合以下要求)

- [x] All tests are passing(所有测试都通过)

## Other information(其他信息)
