### PR TITLE
feat: 支持根目录下直接调试 core 与 vscode plugin

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,62 @@
+// A launch configuration that compiles the extension and then opens it inside a new window
+{
+  "version": "0.1.0",
+  "configurations": [
+      {
+          "name": "debug:vscode-plugin",
+          "type": "extensionHost",
+          "request": "launch",
+          "runtimeExecutable": "${execPath}",
+          "args": [
+              "--extensionDevelopmentPath=${workspaceFolder}/packages/pont-vscode-plugin"
+          ],
+          "stopOnEntry": false,
+          "sourceMaps": true,
+          "outFiles": [
+              "${workspaceFolder}/packages/pont-vscode-plugin/out/**/*.js"
+          ]
+      },
+      {
+          "name": "test:vscode-plugin",
+          "type": "extensionHost",
+          "request": "launch",
+          "runtimeExecutable": "${execPath}",
+          "args": [
+              "--extensionDevelopmentPath=${workspaceFolder}/packages/pont-vscode-plugin",
+              "--extensionTestsPath=${workspaceFolder}/packages/pont-vscode-plugin/out/test"
+          ],
+          "stopOnEntry": false,
+          "sourceMaps": true
+      },
+      {
+        "type": "node",
+        "request": "launch",
+        "name": "test:pont-core",
+        "program": "${workspaceFolder}/packages/pont-core/node_modules/mocha/bin/_mocha",
+        "args": [
+          "-r",
+          "ts-node/register",
+          "--timeout",
+          "15000",
+          "--colors",
+          "${workspaceFolder}/packages/pont-core/test/test.ts"
+        ],
+        "console": "integratedTerminal",
+        "internalConsoleOptions": "neverOpen",
+        "protocol": "inspector"
+      },
+      {
+        "type": "node",
+        "request": "launch",
+        "name": "debug:pont-core",
+        "program": "${workspaceFolder}/packages/pont-core/lib/cmd.js",
+        "args": [
+          "generate"
+        ],
+        "cwd": "${workspaceFolder}/packages/pont-core/",
+        "console": "integratedTerminal",
+        "internalConsoleOptions": "neverOpen",
+        "protocol": "inspector"
+      }
+  ]
+}


### PR DESCRIPTION
## What kind of change does this PR introduce(这个 PR 引入了什么样的变化)?

- [ ] Bugfix(修正错误)
- [ ] Feature(新功能)
- [ ] Refactor(重构)
- [ ] Build-related changes(与构建相关的更改)
- [x] Other, please describe(其他，请描述):

在根目录下添加 `vscode` 相关配置文件，以支持根目录下的调试及 UT。同时使用 `${workspaceFolder}` 代替了 `${workspaceRoot}`。原因：
> Why isn't ${workspaceRoot} documented?
The variable ${workspaceRoot} was deprecated in favor of ${workspaceFolder} to better align with Multi-root Workspace support.

## Does this PR introduce a breaking change(这次 PR 引入了一个重大变化吗)?

- [ ] Yes(是)
- [x] No(否)

If yes, please describe the impact and migration path for existing applications(如果是，请描述现有应用程序的影响和迁移路径):

## The PR fulfills these requirements(PR 符合以下要求)

- [x] All tests are passing(所有测试都通过)

## Other information(其他信息)
