### PR TITLE
swaggerV3 不存在顶层 tags 时使用 operation-object 下的 tags 并集

### DIFF
--- a/packages/pont-core/src/scripts/swagger.ts
+++ b/packages/pont-core/src/scripts/swagger.ts
@@ -209,7 +209,7 @@ class SwaggerInterface {
     let name = '';
     const compileTemplateKeyword = '#/components/schemas/';
 
-    if (!usingOperationId || inter.operationId) {
+    if (!usingOperationId || !inter.operationId) {
       name = getIdentifierFromUrl(inter.path, inter.method, samePath);
     } else {
       name = getIdentifierFromOperatorId(inter.operationId);
@@ -667,7 +667,7 @@ export function transformSwaggerData2Standard(swagger: SwaggerDataSource, usingO
 
 export function transformSwaggerV3Data2Standard(
   swagger: SwaggerV3DataSource,
-  usingOperationId: boolean,
+  usingOperationId = true,
   originName = ''
 ) {
   const compileTemplateKeyword = '#/components/schemas/';

--- a/packages/pont-core/src/scripts/swagger.ts
+++ b/packages/pont-core/src/scripts/swagger.ts
@@ -410,8 +410,19 @@ export function parseSwaggerV3Mods(swagger: SwaggerV3DataSource, defNames: strin
     });
   });
 
+  // 不存在顶层 tags 时使用 operation-object 下的 tags 并集
+  // https://github.com/OAI/OpenAPI-Specification/blob/OpenAPI.next/versions/3.0.0.md#operation-object
   if (!swagger.tags) {
-    swagger.tags = []
+    swagger.tags = [];
+    allSwaggerInterfaces.forEach(({ tags }) => {
+      if (tags && tags.length) {
+        tags.forEach(tag => {
+          if (!swagger.tags.some(u => u.name == tag)) {
+            swagger.tags.push({ name: tag, description: '' });
+          }
+        });
+      }
+    });
   }
 
   swagger.tags.push({

--- a/packages/pont-core/src/scripts/swagger.ts
+++ b/packages/pont-core/src/scripts/swagger.ts
@@ -409,6 +409,11 @@ export function parseSwaggerV3Mods(swagger: SwaggerV3DataSource, defNames: strin
       allSwaggerInterfaces.push(inter);
     });
   });
+
+  if (!swagger.tags) {
+    swagger.tags = []
+  }
+
   swagger.tags.push({
     name: 'defaultModule',
     description: 'defaultModule'


### PR DESCRIPTION
## What kind of change does this PR introduce(这个 PR 引入了什么样的变化)?

- [x] Bugfix(修正错误)
- [ ] Feature(新功能)
- [ ] Refactor(重构)
- [ ] Build-related changes(与构建相关的更改)
- [ ] Other, please describe(其他，请描述):

## Does this PR introduce a breaking change(这次 PR 引入了一个重大变化吗)?

- [ ] Yes(是)
- [x] No(否)

If yes, please describe the impact and migration path for existing applications(如果是，请描述现有应用程序的影响和迁移路径):

## The PR fulfills these requirements(PR 符合以下要求)

- [x] All tests are passing(所有测试都通过)

## Other information(其他信息)

我的情况是使用 Swashbuckle.AspNetCore 生成的 swagger.json 没有顶层 `tags` 字段，所以之前提了一个PR只是把 `swagger.tags` 赋值为空数组，pont 命令执行倒没什么问题，只是不能生成 mods 。后来反复研究，感觉顶层的 `tags` 和每个 `operation-object` 的 `tags` 有相通之处，除了没有 `description`。

另外，我觉得 swaggerV2 在没有顶层 `tags` 的时候也能这么做。