### PR TITLE
feat(all): 多数据源场景，默认拆分api-lock.json到每个数据源目录下

### DIFF
--- a/packages/pont-engine/src/cmd.ts
+++ b/packages/pont-engine/src/cmd.ts
@@ -4,7 +4,6 @@ import * as fs from 'fs-extra';
 import * as debugLog from './debugLog';
 import * as scan from './scan';
 import { createManager } from './utils';
-import { StandardDataSource } from './standard';
 import { generatePontConfig } from './scripts/start';
 
 const packageFilePath = path.join(__dirname, '..', 'package.json');
@@ -39,10 +38,9 @@ function assert(expression: boolean, message: string) {
       .description('检测 api-lock.json 文件')
       .action(async () => {
         debugLog.info('api-lock.json 文件检测中...');
-        const fileContent = await manager.readLockFile();
+        const localDatas = await manager.readLockFile();
 
         try {
-          const localDatas = JSON.parse(fileContent) as StandardDataSource[];
           if (localDatas.length > 1) {
             assert(
               localDatas.every(data => !!data.name),

--- a/packages/pont-engine/src/manage.ts
+++ b/packages/pont-engine/src/manage.ts
@@ -185,38 +185,49 @@ export class Manager {
   existsLocal() {
     return (
       fs.existsSync(path.join(this.currConfig.outDir, this.lockFilename)) ||
-      fs.existsSync(path.join(this.currConfig.outDir, 'api.lock'))
+      _.some(this.allConfigs.map((config) => fs.existsSync(path.join(config.outDir, config.name, this.lockFilename))))
     );
   }
 
-  async readLockFile(): Promise<string> {
-    let lockFile = path.join(this.currConfig.outDir, 'api-lock.json');
-    const isExists = fs.existsSync(lockFile);
-
-    if (!isExists) {
-      lockFile = path.join(this.currConfig.outDir, 'api.lock');
-    }
-
+  async readLockFile(): Promise<Array<StandardDataSource>> {
     try {
-      const localDataStr = await fs.readFile(lockFile, {
-        encoding: 'utf8'
-      });
-      return localDataStr;
+      let lockFile = path.join(this.currConfig.outDir, this.lockFilename);
+      const isExists = fs.existsSync(lockFile);
+      /** 兼容上一版本数据源根目录生成api-lock.json的场景 */
+      if (isExists) {
+        const localDataStr = await fs.readFile(lockFile, {
+          encoding: 'utf8'
+        });
+        if (this.allConfigs.length > 1) {
+          /** 多数据源的场景，删除原来的lock文件 */
+          this.regenerateFiles().then(() => fs.rename(lockFile, `${lockFile}.bak`));
+        }
+        return JSON.parse(localDataStr);
+      } else {
+        const allFilePromises = this.allConfigs.map(async (config) => {
+          const filePath = path.join(config.outDir, config.name, this.lockFilename);
+          const localDataStr = await fs.readFile(filePath, {
+            encoding: 'utf8'
+          });
+          return JSON.parse(localDataStr);
+        });
+        return Promise.all(allFilePromises);
+      }
     } catch (error) {
-      return '';
+      this.report(error);
+      return [];
     }
   }
 
   async readLocalDataSource() {
     try {
       this.report('读取本地数据中...');
-      const localDataStr = await this.readLockFile();
-      if (!localDataStr) {
+      const localDataObjects = await this.readLockFile();
+      if (!localDataObjects.length) {
         return;
       }
 
       this.report('读取本地完成');
-      const localDataObjects = JSON.parse(localDataStr) as StandardDataSource[];
 
       this.allLocalDataSources = localDataObjects.map(ldo => {
         return StandardDataSource.constructorFromLock(ldo, ldo.name);
@@ -227,6 +238,7 @@ export class Manager {
         return Boolean(this.allConfigs.find(config => config.name === ldo.name));
       });
 
+      // 本地数据源和远程数据源不一致
       if (this.allLocalDataSources.length < this.allConfigs.length) {
         this.allConfigs.forEach(config => {
           if (!this.allLocalDataSources.find(ds => ds.name === config.name)) {
@@ -256,7 +268,7 @@ export class Manager {
       this.setFilesManager();
       this.report('本地对象创建成功');
     } catch (e) {
-      throw new Error('读取 lock 文件错误！' + e.toString());
+      throw new Error('读取 api-lock.json 文件错误！' + e.toString());
     }
   }
 
@@ -341,7 +353,7 @@ export class Manager {
   }
 
   async lock() {
-    await this.fileManager.saveLock();
+    await this.fileManager.saveLock(this.currConfig.name);
   }
 
   dispatch(files: {}) {
@@ -395,7 +407,7 @@ export class Manager {
 
     const generators = this.allLocalDataSources.map(dataSource => {
       const config = this.getConfigByDataSourceName(dataSource.name);
-      const generator: CodeGenerator = new Generator(this.currConfig.surrounding, config?.outDir);
+      const generator: CodeGenerator = new Generator(this.currConfig.surrounding, config?.outDir, this.lockFilename);
       generator.setDataSource(dataSource);
       generator.usingMultipleOrigins = this.currConfig.usingMultipleOrigins;
 

--- a/packages/vscode-pont/src/UI.ts
+++ b/packages/vscode-pont/src/UI.ts
@@ -127,16 +127,12 @@ export class Control {
   watchLocalFile() {
     const config = this.manager.currConfig;
     const lockWatcher = vscode.workspace.createFileSystemWatcher(
-      path.join(config.outDir, 'api.lock'),
+      path.join(config.outDir, this.manager.lockFilename),
       true,
       false,
       true
     );
     let lockDispose = lockWatcher.onDidChange(async () => {
-      if (this.manager.fileManager.created) {
-        this.manager.fileManager.created = false;
-        return;
-      }
       await this.manager.readLocalDataSource();
       this.manager.calDiffs();
       this.ui.reRender();
@@ -280,7 +276,7 @@ export class Control {
             title: 'updateMod'
           },
           p => {
-            return new Promise(async (resolve, reject) => {
+            return new Promise<void>(async (resolve, reject) => {
               try {
                 p.report({ message: '开始更新...' });
 
@@ -330,7 +326,7 @@ export class Control {
             title: 'updateBo'
           },
           p => {
-            return new Promise(async (resolve, reject) => {
+            return new Promise<void>(async (resolve, reject) => {
               try {
                 p.report({ message: '开始更新...' });
 
@@ -368,7 +364,7 @@ export class Control {
             title: 'updateAll'
           },
           p => {
-            return new Promise(async (resolve, reject) => {
+            return new Promise<void>(async (resolve, reject) => {
               try {
                 p.report({ message: '开始更新...' });
 


### PR DESCRIPTION
## What kind of change does this PR introduce(这个 PR 引入了什么样的变化)?

- [ ] Bugfix(修正错误)
- [ ] Feature(新功能)
- [x] Refactor(重构)
- [ ] Build-related changes(与构建相关的更改)
- [ ] Other, please describe(其他，请描述):

## Does this PR introduce a breaking change(这次 PR 引入了一个重大变化吗)?

- [x] Yes(是)
- [ ] No(否)

If yes, please describe the impact and migration path for existing applications(如果是，请描述现有应用程序的影响和迁移路径):
多数据源的场景，打开vscode检测api-lock.json之后会将其备份为api-lock.json.bak，然后在数据源子目录下重新生成独立的api-lock.json


## The PR fulfills these requirements(PR 符合以下要求)

- [ ] All tests are passing(所有测试都通过)

## Other information(其他信息)

1、有一个破坏性变更，用户如果覆盖了`pontTemplate.ts`文件中的以下函数，需要适应性调整：
**getOriginFileStructures**、**getMultipleOriginsFileStructures**、**getLockContent**
2、不再兼容api.lock（实际上部分代码也没有做兼容），全部以api-lock.json这个文件为准
