### PR TITLE
fix: SwaggerV3 中 requestBody 参数的类型永远是 any

### DIFF
--- a/packages/pont-engine/src/scripts/swagger.ts
+++ b/packages/pont-engine/src/scripts/swagger.ts
@@ -50,9 +50,9 @@ class SwaggerParameter {
   required: boolean;
 
   /** 类型 */
-  type: SwaggerType;
+  type?: SwaggerType;
 
-  enum: string[];
+  enum?: string[];
 
   items? = null as {
     type?: SwaggerType;
@@ -60,6 +60,20 @@ class SwaggerParameter {
   };
 
   schema: Schema;
+}
+
+class SwaggerRequestBody {
+  /** 描述 */
+  description = '';
+
+  /** 是否必填 */
+  required: boolean;
+
+  content = null as {
+    [key: string]: {
+      schema: Schema;
+    };
+  };
 }
 
 class Schema {
@@ -186,6 +200,8 @@ class SwaggerInterface {
   consumes = [] as string[];
 
   parameters = [] as SwaggerParameter[];
+
+  requestBody = {} as SwaggerRequestBody
 
   summary = '';
 
@@ -407,14 +423,17 @@ export function parseSwaggerV3Mods(swagger: SwaggerV3DataSource, defNames: strin
       inter.method = method;
 
       if (inter.requestBody) {
-        const requestBodyContent = _.get(inter, 'requestBody.content', {})
+        const requestBodyContent = _.get(inter, 'requestBody.content', {});
         const requestFormat = Object.keys(requestBodyContent)[0];
-        inter.parameters = [{
-          name: 'requestBody',
-          in: 'body',
-          required: inter.requestBody.required,
-          schema: _.get(requestBodyContent, `${requestFormat}.schema`, {})
-        }]
+        inter.parameters = [
+          {
+            name: 'requestBody',
+            in: 'body',
+            description: inter.requestBody.description,
+            required: inter.requestBody.required,
+            schema: _.get(requestBodyContent, `${requestFormat}.schema`, {})
+          }
+        ];
       }
 
       if (!inter.tags) {

--- a/packages/pont-engine/src/scripts/swagger.ts
+++ b/packages/pont-engine/src/scripts/swagger.ts
@@ -402,21 +402,20 @@ export function parseSwaggerV3Mods(swagger: SwaggerV3DataSource, defNames: strin
   _.forEach(swagger.paths, (methodInters, path) => {
     const pathItemObject = _.cloneDeep(methodInters);
 
-    if (Array.isArray(pathItemObject.parameters)) {
-      ['get', 'post', 'patch', 'delete', 'put'].forEach(method => {
-        if (pathItemObject[method]) {
-          pathItemObject[method].parameters = (pathItemObject[method].parameters || []).concat(
-            pathItemObject.parameters
-          );
-        }
-      });
-
-      delete pathItemObject.parameters;
-    }
-
     _.forEach(pathItemObject as Omit<SwaggerPathItemObject, 'parameters'>, (inter, method) => {
       inter.path = path;
       inter.method = method;
+
+      if (inter.requestBody) {
+        const requestBodyContent = _.get(inter, 'requestBody.content', {})
+        const requestFormat = Object.keys(requestBodyContent)[0];
+        inter.parameters = [{
+          name: 'requestBody',
+          in: 'body',
+          required: requestBodyContent.required,
+          schema: _.get(requestBodyContent, `${requestFormat}.schema`, {})
+        }]
+      }
 
       if (!inter.tags) {
         inter.tags = ['defaultModule'];

--- a/packages/pont-engine/src/scripts/swagger.ts
+++ b/packages/pont-engine/src/scripts/swagger.ts
@@ -412,7 +412,7 @@ export function parseSwaggerV3Mods(swagger: SwaggerV3DataSource, defNames: strin
         inter.parameters = [{
           name: 'requestBody',
           in: 'body',
-          required: requestBodyContent.required,
+          required: inter.requestBody.required,
           schema: _.get(requestBodyContent, `${requestFormat}.schema`, {})
         }]
       }


### PR DESCRIPTION
close #313

## What kind of change does this PR introduce(这个 PR 引入了什么样的变化)?

- [x] Bugfix(修正错误)
- [ ] Feature(新功能)
- [ ] Refactor(重构)
- [ ] Build-related changes(与构建相关的更改)
- [ ] Other, please describe(其他，请描述):

## Does this PR introduce a breaking change(这次 PR 引入了一个重大变化吗)?

- [ ] Yes(是)
- [x] No(否)

If yes, please describe the impact and migration path for existing applications(如果是，请描述现有应用程序的影响和迁移路径):

## The PR fulfills these requirements(PR 符合以下要求)

- [ ] All tests are passing(所有测试都通过)

## Other information(其他信息)
SwaggerV3 中 `body` 参数被单独保存在 `requestBody` 字段中，而不是像 V2 一样保存在 parameters 里面：
![image](https://user-images.githubusercontent.com/21048878/174433986-177a2149-a97f-4693-acec-11f9de2093bd.png)
![image](https://user-images.githubusercontent.com/21048878/174434029-aca14011-82fa-4693-b785-a84b5eae3137.png)
