### PR TITLE
fix: 更正 重写 FileStructures 的介绍

### DIFF
--- a/docs/customizedPont.md
+++ b/docs/customizedPont.md
@@ -115,13 +115,14 @@ function filterModsAndBaseClass(filterMods: string[], data: StandardDataSource) 
 
 **类型**
 ```javascript
+import * as Pont from 'pont-engine'
 import { CodeGenerator, FileStructures } from 'pont-engine';
 
 // 代码生成器
 export default class MyCodeGenerator extends CodeGenerator {}
 
 // 文件结构生成
-export class MyFileStructures extends FileStructures {}
+export class FileStructures extends Pont.FileStructures {}
 ```
 #### CodeGenerator 
 代码生成器


### PR DESCRIPTION
## 修改 templatePath 中的 FileStructures 介绍 避免发生错误引导，更好的介绍 api 功能

- [ ] Bugfix(修正错误)

在官方的 customizedPont.md 介绍中 export 一个 MyFileStructures 即可 重写 FileStructures 的方法，但在 1.3.3 的版本中并不生效, 通过查看源码发现 Manager 类中的 setFilesManager 取值是 FileStructures 并非  MyFileStructures，所以写法是错误的，更正为 FileStructures

```javascript
import { FileStructures as ParentFileStructures } from 'pont-engine'
export class FileStructures extends ParentFileStructures {}
```

## Does this PR introduce a breaking change(这次 PR 引入了一个重大变化吗)?
- [ ] No(否)

## The PR fulfills these requirements(PR 符合以下要求)

- [ ] All tests are passing(所有测试都通过)
- [ ] Yes(是)
