### PR TITLE
fix:generate中getBaseClassInDeclaration函数解析泛型问题

### DIFF
--- a/packages/pont-engine/src/compatible/generators/generate.ts
+++ b/packages/pont-engine/src/compatible/generators/generate.ts
@@ -264,15 +264,60 @@ export class CodeGenerator {
 
   /** 获取某个基类的类型定义代码 */
   getBaseClassInDeclaration(base: BaseClass) {
+
     if (base.templateArgs && base.templateArgs.length) {
       return `class ${base.name}<${base.templateArgs.map((_, index) => `T${index} = any`).join(', ')}> {
-        ${base.properties.map((prop) => prop.toPropertyCode(Surrounding.typeScript, true)).join('\n')}
+        ${base.properties.map(
+          (prop) => {
+            const index = base.templateArgs.findIndex(ele => ele.typeName === prop.dataType.typeName)
+            if (index !== -1) {
+              // 复写这个部分
+              // 直接判断是否相等 相等然后找到匹配的泛型，放进去
+              let fieldTypeDeclaration = `: T${index}`
+              return `
+              /** ${prop.description || prop.name} */
+              ${prop.name}${fieldTypeDeclaration};`;
+            }
+            // 等于-1可能是array套嵌
+            const deepArgs = function (deepProp: StandardDataType) {
+              const index = base.templateArgs.findIndex(ele => ele.typeName === deepProp.typeName)
+              if (index !== -1) {
+                return `Array<T${index}>`
+              }
+              if (deepProp.typeName === 'Array') {
+                const len = deepProp.typeArgs.length
+                for (let i = 0; i < len; i++) {
+                  const arg = deepProp.typeArgs[i]
+                  const result = deepArgs(arg)
+                  if (result) {
+                    return result
+                  }
+                }
+              }
+              return false
+            }
+
+            if (prop.dataType.typeName === 'Array') {
+              let len = prop.dataType.typeArgs.length
+              for (let i = 0; i < len; i++) {
+                const arg = prop.dataType.typeArgs[i]
+                const result = deepArgs(arg)
+                if (result) {
+                  return `
+                  /** ${prop.description || prop.name} */
+                  ${prop.name}: ${result};`;
+                }
+              }
+            }
+            return prop.toPropertyCode(Surrounding.typeScript, true)
+          }
+          ).join('\n')}
       }
       `;
     }
     return `class ${base.name} {
-      ${base.properties.map((prop) => prop.toPropertyCode(Surrounding.typeScript, true)).join('\n')}
-    }
+        ${base.properties.map((prop) => prop.toPropertyCode(Surrounding.typeScript, true)).join('\n')}
+      }
     `;
   }
 


### PR DESCRIPTION
修复getBaseClassInDeclaration函数默认baseclass中解析泛型的问题；
例如： 
export class DataPagingQueryResults<T0 = any> {
      /** code */
      xxx: xxx;

      /** data */
      data: defs.river.PageResult<defs.river.SiteInformation>;
    }

将会变成：
export class DataPagingQueryResults<T0 = any> {
      /** code */
      xxx: xxx;

      /** data */
      data: defs.river.PageResult<T0>;
    }

## What kind of change does this PR introduce(这个 PR 引入了什么样的变化)?

- [x] Bugfix(修正错误)
- [ ] Feature(新功能)
- [ ] Refactor(重构)
- [ ] Build-related changes(与构建相关的更改)
- [ ] Other, please describe(其他，请描述):

## Does this PR introduce a breaking change(这次 PR 引入了一个重大变化吗)?

- [ ] Yes(是)
- [x] No(否)

If yes, please describe the impact and migration path for existing applications(如果是，请描述现有应用程序的影响和迁移路径):

## The PR fulfills these requirements(PR 符合以下要求)

- [ ] All tests are passing(所有测试都通过)

## Other information(其他信息)
