### PR TITLE
fix(pont-engine): 中文 enum 值被过滤了

### DIFF
--- a/packages/pont-engine/src/compatible/scripts/swagger.ts
+++ b/packages/pont-engine/src/compatible/scripts/swagger.ts
@@ -182,25 +182,7 @@ class Schema {
 }
 
 export function parseSwaggerEnumType(enumStrs: string[]) {
-  let enums = enumStrs as Array<string | number>;
-
-  enumStrs.forEach((str) => {
-    if (!Number.isNaN(Number(str))) {
-      enums.push(Number(str));
-    }
-  });
-
-  return enums
-    .filter((str) => {
-      return String(str).match(/^[0-9a-zA-Z\_\-\$]+$/);
-    })
-    .map((numOrStr) => {
-      if (typeof numOrStr === 'string') {
-        return `'${numOrStr}'`;
-      }
-
-      return numOrStr;
-    });
+  return enumStrs
 }
 
 class SwaggerInterface {


### PR DESCRIPTION
## What kind of change does this PR introduce(这个 PR 引入了什么样的变化)?

- [x] Bugfix(修正错误)
- [ ] Feature(新功能)
- [ ] Refactor(重构)
- [ ] Build-related changes(与构建相关的更改)
- [ ] Other, please describe(其他，请描述):

## Does this PR introduce a breaking change(这次 PR 引入了一个重大变化吗)?

- [ ] Yes(是)
- [x] No(否)

If yes, please describe the impact and migration path for existing applications(如果是，请描述现有应用程序的影响和迁移路径):

## The PR fulfills these requirements(PR 符合以下要求)

- [ ] All tests are passing(所有测试都通过)

## Other information(其他信息)
后端 enum 类：
```java
@Getter
public enum UserSex {
	MALE(1, "男"), FEMALE(2, "女"), UNKNOWN(0, "未知");

	@EnumValue
	private final int value;
	@JsonValue
	private final String name;

	UserSex(int value, String name) {
		this.value = value;
		this.name = name;
	}
}
```
 swagger 接口数据：
```json
"UserEntity": {
                "type": "object",
                "properties": {
                    "id": {
                        "type": "string"
                    },
                    "sex": {
                        "type": "string",
                        "description": "性别",
                        "enum": [
                            "男",
                            "女",
                            "未知"
                        ]
                    },
                },
                "description": "用户"
            }
```
现在的版本会过滤中文导致生成的接口不完整：
https://github.com/alibaba/pont/blob/9b52665e1b9906d220a9dbaa284a0c16f4447452/packages/pont-engine/src/compatible/scripts/swagger.ts#L184-L196